### PR TITLE
Spike: property based testing

### DIFF
--- a/lib/coordinate.rb
+++ b/lib/coordinate.rb
@@ -7,7 +7,8 @@ class Coordinate
   end
 
   def distance_from(other)
-    # TODO: actually caluculate distance. I think we need to use the Pythagorean theorem?
-    0
+    dx = other.x - x
+    dy = other.y - y
+    Math.sqrt(dx*dx+dy*dy)
   end
 end

--- a/spec/shouty_spec.rb
+++ b/spec/shouty_spec.rb
@@ -1,0 +1,21 @@
+require 'rantly/rspec_extensions'
+require 'shouty'
+require 'coordinate'
+
+describe Shouty do
+  it "only tranmits shouts within 1000m" do
+    property_of {
+      shouter_loc  = Coordinate.new(*Rantly(2) { range(0, 2000) })
+      listener_loc = Coordinate.new(*Rantly(2) { range(0, 2000) })
+      guard shouter_loc.distance_from(listener_loc) < 1000
+
+      [shouter_loc, listener_loc]
+    }.check { |shouter_loc, listener_loc|
+      shouty = Shouty.new
+      shouty.set_location('shouter', shouter_loc)
+      shouty.set_location('listener', listener_loc)
+      shouty.shout('shouter', listener_loc)
+      expect(shouty.messages_heard_by('listener').length).to eq(1)
+    }
+  end
+end


### PR DESCRIPTION
Over at cucumber/cucumber#250 there is a discussion about adding a `Rule` keyword to Gherkin. This pull-request should not be merged - it's only here for illustration and discussion.

I wanted to get a feel for what this would be like, so I wrote a simple RSpec example for our familiar Shouty codebase. 

If we were to add the `Rule` keyword to Gherkin, we could write this instead:

```gherkin
Feature: Hear Shout

  Rule: Shouts have a range of 1000m

    Scenario: In range shout is heard
      Given Lucy is at 0, 0
      And Sean is at 0, 900
      When Sean shouts
      Then Lucy should hear Sean

    Scenario: Out of range shout is not heard
      Given Lucy is at 0, 0
      And Sean is at 0, 1100
      When Sean shouts
      Then Lucy should hear nothing
```

This brings the Gherkin structure closer to [Example Mapping](https://cucumber.io/blog/2015/12/08/example-mapping-introduction).

It also makes it possible to (optionally) test the rule with a property based tool:

```ruby
Rule('Shouts have a range of {int}m') do |range|
  property_of {
    shouter_loc  = Coordinate.new(*Rantly(2) { range(0, 2000) })
    listener_loc = Coordinate.new(*Rantly(2) { range(0, 2000) })
    guard shouter_loc.distance_from(listener_loc) < range

    [shouter_loc, listener_loc]
  }.check { |shouter_loc, listener_loc|
    shouty = Shouty.new
    shouty.set_location('shouter', shouter_loc)
    shouty.set_location('listener', listener_loc)
    shouty.shout('shouter', listener_loc)
    expect(shouty.messages_heard_by('listener').length).to eq(1)
  }
end
```

Apart from changing the Gherkin grammar to allow for this, I don't think this would require a massive change in Cucumber itself. The rule can be thought of a 1-step scenario that (conventionally) uses a property based testing in its body.