### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM  ruby:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  ruby:
+    build:
+      context: .
+    working_dir: /app
+    volumes:
+      - .:/app:delegated
+    entrypoint:
+      - /bin/bash


### PR DESCRIPTION
This PR adds a simple Dockerfile + docker-compose for creating a Ruby shell for development, mounting the working directory into the container.

Simplifies project configuration when attendees will work locally.

Run with `docker-compose run --rm ruby`.

I haven't updated the README, as that belongs in the Computer Setup.